### PR TITLE
Updateed database.yml.template

### DIFF
--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -6,8 +6,8 @@
 #
 default: &default
  adapter: sqlite3
--  pool: 5
-+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+ pool: 5
+ pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000
 
 development:

--- a/config/database.yml.template
+++ b/config/database.yml.template
@@ -6,7 +6,6 @@
 #
 default: &default
  adapter: sqlite3
- pool: 5
  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
  timeout: 5000
 


### PR DESCRIPTION
### Summary

There was a rogue "+" and "-" that snuck into this file causing installation errors on:

<pre>
./bin/setup
</pre>

### Error

For reference here is the error:
<pre>
== Preparing database ==
rails aborted!
YAML syntax error occurred while parsing /root/github/dradis-ce/config/database.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Error: (<unknown>): did not find expected key while parsing a block mapping at line 7 column 1
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application/configuration.rb:144:in `rescue in database_configuration'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application/configuration.rb:127:in `database_configuration'
/root/github/dradis-ce/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/railtie.rb:34:in `block (3 levels) in <class:Railtie>'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/commands/rake/rake_command.rb:21:in `block in perform'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/command.rb:46:in `invoke'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/commands.rb:16:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Psych::SyntaxError: (<unknown>): did not find expected key while parsing a block mapping at line 7 column 1
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/application/configuration.rb:133:in `database_configuration'
/root/github/dradis-ce/ruby/2.3.0/gems/activerecord-5.1.3/lib/active_record/railtie.rb:34:in `block (3 levels) in <class:Railtie>'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/commands/rake/rake_command.rb:21:in `block in perform'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/command.rb:46:in `invoke'
/root/github/dradis-ce/ruby/2.3.0/gems/railties-5.1.3/lib/rails/commands.rb:16:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => db:setup => db:schema:load_if_ruby => db:create => db:load_config
(See full trace by running task with --trace)

== Command ["bin/rails db:setup"] failed ==
</pre>